### PR TITLE
Rebind all queues after reconnect

### DIFF
--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -17,7 +17,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="12.1.1" />
+    <PackageReference Include="atisu.services.common" Version="12.1.2-rc1" />
     <PackageReference Include="EasyNetQ" Version="6.3.1" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/EventbusManager.cs
+++ b/ATI.Services.RabbitMQ/EventbusManager.cs
@@ -201,19 +201,14 @@ namespace ATI.Services.RabbitMQ
 
             RabbitMqDeclaredQueues.DeclaredQueues.Add(bindingInfo.Queue);
 
-            if (_busClient.IsConnected)
+            try
             {
-                try
-                {
-                    await SubscribePrivateAsync(bindingInfo, handler, metricEntity);
-                }
-                // В интервале между проверкой _busClient.IsConnected и SubscribeAsyncPrivate Rabbit может отвалиться, поэтому запускаем в бекграунд потоке
-                catch (Exception ex)
-                {
-                    _logger.Error(ex);
-                    _subscribePolicy.ExecuteAsync(async () =>
-                        await SubscribePrivateAsync(bindingInfo, handler, metricEntity)).Forget();
-                }
+                await SubscribePrivateAsync(bindingInfo, handler, metricEntity);
+            }
+            // В интервале между проверкой _busClient.IsConnected и SubscribeAsyncPrivate Rabbit может отвалиться, поэтому запускаем в бекграунд потоке
+            catch (Exception ex)
+            {
+                _logger.Error(ex);
             }
         }
 

--- a/ATI.Services.RabbitMQ/EventbusManager.cs
+++ b/ATI.Services.RabbitMQ/EventbusManager.cs
@@ -66,7 +66,7 @@ namespace ATI.Services.RabbitMQ
                 Policy.Handle<Exception>()
                     .WaitAndRetryForeverAsync(
                         retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, Math.Min(retryAttempt, MaxRetryDelayPow))),
-                        (exception, _) => _logger.ErrorWithObject(exception, _subscriptions));
+                        (exception, _) => _logger.ErrorWithObject(exception));
         }
 
         public Task InitializeAsync()
@@ -259,7 +259,7 @@ namespace ATI.Services.RabbitMQ
             }
             catch (Exception e)
             {
-                _logger.ErrorWithObject(e, _subscriptions);
+                _logger.ErrorWithObject(e);
             }
         }
 

--- a/ATI.Services.RabbitMQ/EventbusManager.cs
+++ b/ATI.Services.RabbitMQ/EventbusManager.cs
@@ -239,7 +239,14 @@ namespace ATI.Services.RabbitMQ
             {
                 try
                 {
-                    await DeclareBindQueue(subscription.Binding);
+                    if (subscription.Binding.Queue.IsExclusive)
+                    {
+                        await SubscribePrivateAsync(subscription.Binding,
+                                                    subscription.EventbusSubscriptionHandler,
+                                                    subscription.MetricsEntity);
+                    }
+                    else
+                        await DeclareBindQueue(subscription.Binding);
                 }
                 catch (Exception e)
                 {

--- a/ATI.Services.RabbitMQ/EventbusManager.cs
+++ b/ATI.Services.RabbitMQ/EventbusManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -40,7 +41,7 @@ namespace ATI.Services.RabbitMQ
             MetricsFactory.CreateRepositoryMetricsFactory(nameof(EventbusManager));
 
         private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
-        private List<SubscriptionInfo> _subscriptions = new();
+        private ConcurrentBag<SubscriptionInfo> _subscriptions = new();
         private readonly AsyncRetryPolicy _retryForeverPolicy;
         private readonly AsyncRetryPolicy _subscribePolicy;
         private readonly EventbusOptions _options;


### PR DESCRIPTION
### Bugfixes
- fixes exception that occurs in case of handling rmq message with unsupported locale(message will be lost), now it will be handled with default locale  
### Changes
Resubscribe logic added, now all queues will be created in case of connection problems with rmq.

On `Connected` event the following will happen:
- create and bind to exchange all subscriptions
- for exclusive queues also `.Consume(...)` will be invoked (for ordinal queues we'll reuse consumer created on init)