### PR TITLE
Update newtonsofthjson and RabbitMQ

### DIFF
--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -17,7 +17,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="11.3.3-netonsoft-ver13" />
+    <PackageReference Include="atisu.services.common" Version="11.4.1-newtonsoft-ver13" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -17,7 +17,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="10.0.3" />
-    <PackageReference Include="EasyNetQ" Version="6.3.1" />
+    <PackageReference Include="atisu.services.common" Version="11.3.3-netonsoft-ver13" />
+    <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -17,7 +17,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="12.3.0-newtonsoft-v13-rc1" />
+    <PackageReference Include="atisu.services.common" Version="12.3.0" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
+++ b/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
@@ -1,19 +1,17 @@
-﻿using System.Collections.Generic;
-using EasyNetQ.Topology;
+﻿using EasyNetQ.Topology;
 
 namespace ATI.Services.RabbitMQ
 {
     public class QueueExchangeBinding
     {
-        public QueueExchangeBinding(ExchangeInfo exchange, IQueue queue, string routingKey)
+        public QueueExchangeBinding(ExchangeInfo exchange, Queue queue, string routingKey)
         {
             Queue = queue;
             RoutingKey = routingKey;
             Exchange = exchange;
-            List<decimal> d = new List<decimal>();
         }
 
-        public IQueue Queue { get; }
+        public Queue Queue { get; }
         public string RoutingKey { get; }
         public ExchangeInfo Exchange { get; }
     }

--- a/ATI.Services.RabbitMQ/RabbitMqDeclaredQueues.cs
+++ b/ATI.Services.RabbitMQ/RabbitMqDeclaredQueues.cs
@@ -5,6 +5,6 @@ namespace ATI.Services.RabbitMQ
 {
     public static class RabbitMqDeclaredQueues
     {
-        public static List<IQueue> DeclaredQueues { get; } = new();
+        public static List<Queue> DeclaredQueues { get; } = new();
     }
 }


### PR DESCRIPTION
- upgrades atisu.services.common due to [newtonsoft.json vulnerability](https://devhub.checkmarx.com/cve-details/Cx46691637-14e8/)
- upgrades RabbitMQ due to dependency from vulnerable newtonsoft.json version