### PR TITLE
New metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
+          dotnet-version: '7.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
       - name: Build
         run: dotnet build --configuration Release

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
+          dotnet-version: '7.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
       - name: Pack
         run: dotnet pack --configuration Release /p:Version=${VERSION} --output .
       - name: Push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with: 
-          dotnet-version: '6.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
+          dotnet-version: '7.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
       - name: Build
         run: dotnet build --configuration Release /p:Version=${VERSION}
       - name: Pack

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-rc1.0" />
+    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-rc1.2" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-8" />
+    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-10" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-rc1.2" />
+    <PackageReference Include="atisu.services.common" Version="13.7.0" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-5" />
+    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-7" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-7" />
+    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-8" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Main">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
     <Authors>Team Services</Authors>
     <Company>ATI</Company>
-    <LangVersion>10</LangVersion>
     <PublishReadyToRun>true</PublishReadyToRun>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>atisu.services.rabbitmq</PackageId>
@@ -17,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="12.3.0" />
+    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-5" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-alpha-10" />
+    <PackageReference Include="atisu.services.common" Version="13.7.0-group-metrics-rc1.0" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/EventbusManager.cs
+++ b/ATI.Services.RabbitMQ/EventbusManager.cs
@@ -38,7 +38,7 @@ public class EventbusManager : IDisposable, IInitializer
     private readonly JsonSerializer _jsonSerializer;
     private readonly string _connectionString;
 
-    private readonly MetricsFactory _inMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsDirection.In, nameof(EventbusManager), additionalSummaryLabels: "client_header_name");
+    private readonly MetricsFactory _inMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsDirection.In, nameof(EventbusManager), additionalSummaryLabels: "rmq_app_id");
     private readonly MetricsFactory _outMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsDirection.Out, nameof(EventbusManager));
 
     private readonly ILogger _logger = LogManager.GetCurrentClassLogger();

--- a/ATI.Services.RabbitMQ/EventbusManager.cs
+++ b/ATI.Services.RabbitMQ/EventbusManager.cs
@@ -26,380 +26,381 @@ using Polly.Retry;
 using Polly.Wrap;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 
-namespace ATI.Services.RabbitMQ
+namespace ATI.Services.RabbitMQ;
+
+[PublicAPI]
+[InitializeOrder(Order = InitializeOrder.First)]
+public class EventbusManager : IDisposable, IInitializer
 {
-    [PublicAPI]
-    [InitializeOrder(Order = InitializeOrder.First)]
-    public class EventbusManager : IDisposable, IInitializer
+    private IAdvancedBus _busClient;
+    private const int RetryAttemptMax = 3;
+    private const int MaxRetryDelayPow = 2;
+    private readonly JsonSerializer _jsonSerializer;
+    private readonly string _connectionString;
+
+    private readonly MetricsFactory _inMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsDirection.In, nameof(EventbusManager), additionalSummaryLabels: "client_header_name");
+    private readonly MetricsFactory _outMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsDirection.Out, nameof(EventbusManager));
+
+    private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
+    private ConcurrentBag<SubscriptionInfo> _subscriptions = new();
+    private readonly AsyncRetryPolicy _retryForeverPolicy;
+    private readonly AsyncRetryPolicy _subscribePolicy;
+    private readonly EventbusOptions _options;
+    private static readonly UTF8Encoding BodyEncoding = new(false);
+    private readonly RmqTopology _rmqTopology;
+
+    public EventbusManager(JsonSerializer jsonSerializer,
+                           IOptions<EventbusOptions> options, RmqTopology rmqTopology)
     {
-        private IAdvancedBus _busClient;
-        private const int RetryAttemptMax = 3;
-        private const int MaxRetryDelayPow = 2;
-        private readonly JsonSerializer _jsonSerializer;
-        private readonly string _connectionString;
+        _options = options.Value;
+        _connectionString = options.Value.ConnectionString;
+        _jsonSerializer = jsonSerializer;
+        _rmqTopology = rmqTopology;
 
-        private readonly MetricsFactory _metricsTracingFactory =
-            MetricsFactory.CreateRepositoryMetricsFactory(nameof(EventbusManager));
+        _subscribePolicy = Policy.Handle<Exception>()
+                                 .WaitAndRetryForeverAsync(
+                                     _ => _options.RabbitConnectInterval,
+                                     (exception, _) => _logger.Error(exception));
 
-        private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
-        private ConcurrentBag<SubscriptionInfo> _subscriptions = new();
-        private readonly AsyncRetryPolicy _retryForeverPolicy;
-        private readonly AsyncRetryPolicy _subscribePolicy;
-        private readonly EventbusOptions _options;
-        private static readonly UTF8Encoding BodyEncoding = new(false);
-        private readonly RmqTopology _rmqTopology;
+        _retryForeverPolicy =
+            Policy.Handle<Exception>()
+                  .WaitAndRetryForeverAsync(
+                      retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, Math.Min(retryAttempt, MaxRetryDelayPow))),
+                      (exception, _) => _logger.ErrorWithObject(exception));
+    }
 
-        public EventbusManager(JsonSerializer jsonSerializer,
-                               IOptions<EventbusOptions> options, RmqTopology rmqTopology)
+    public Task InitializeAsync()
+    {
+        try
         {
-            _options = options.Value;
-            _connectionString = options.Value.ConnectionString;
-            _jsonSerializer = jsonSerializer;
-            _rmqTopology = rmqTopology;
+            _busClient = RabbitHutch.CreateBus(_connectionString,
+                                               serviceRegister =>
+                                               {
+                                                   serviceRegister.Register<IConventions>(c =>
+                                                       new RabbitMqConventions(c.Resolve<ITypeNameSerializer>(), _options));
+                                               }).Advanced;
 
-            _subscribePolicy = Policy.Handle<Exception>()
-                .WaitAndRetryForeverAsync(
-                    _ => _options.RabbitConnectInterval,
-                    (exception, _) => _logger.Error(exception));
-
-            _retryForeverPolicy =
-                Policy.Handle<Exception>()
-                    .WaitAndRetryForeverAsync(
-                        retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, Math.Min(retryAttempt, MaxRetryDelayPow))),
-                        (exception, _) => _logger.ErrorWithObject(exception));
+            _busClient.Connected += async (_, _) => await ResubscribeOnReconnect();
+            _busClient.Disconnected += (_, _) => { _logger.Error("Disconnected from RMQ for some reason!"); };
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception);
         }
 
-        public Task InitializeAsync()
+        return Task.CompletedTask;
+    }
+
+    public Task<Exchange> DeclareExchangeTopicAsync(string exchangeName, bool durable, bool autoDelete) => 
+        _busClient.ExchangeDeclareAsync(exchangeName, ExchangeType.Topic, durable, autoDelete);
+
+    public async Task PublishRawAsync(
+        string publishBody,
+        string exchangeName,
+        string routingKey,
+        string metricEntity,
+        Dictionary<string, object> additionalHeaders = null,
+        bool mandatory = false,
+        TimeSpan? timeout = null,
+        bool withAcceptLang = true)
+    {
+        if (string.IsNullOrWhiteSpace(exchangeName) || string.IsNullOrWhiteSpace(routingKey) ||
+            string.IsNullOrWhiteSpace(publishBody))
+            return;
+
+        using (_outMetricsFactory.CreateLoggingMetricsTimer(metricEntity, $"{exchangeName}:{routingKey}"))
+        {
+            var messageProperties = GetProperties(additionalHeaders, withAcceptLang);
+            var exchange = new Exchange(exchangeName);
+            var body = BodyEncoding.GetBytes(publishBody);
+
+            var sendingResult = await SetupPolicy(timeout).ExecuteAndCaptureAsync(async () =>
+                                    await _busClient.PublishAsync(
+                                        exchange,
+                                        routingKey,
+                                        mandatory,
+                                        messageProperties,
+                                        body));
+
+            if (sendingResult.FinalException != null)
+            {
+                _logger.ErrorWithObject(sendingResult.FinalException,
+                                        new { publishBody, exchangeName, routingKey, metricEntity, mandatory });
+            }
+        }
+    }
+
+    public async Task PublishAsync<T>(
+        T publishObject,
+        string exchangeName,
+        string routingKey,
+        string metricEntity,
+        Dictionary<string, object> additionalHeaders = null,
+        bool mandatory = false,
+        JsonSerializer serializer = null,
+        TimeSpan? timeout = null,
+        bool withAcceptLang = true)
+    {
+        if (string.IsNullOrWhiteSpace(exchangeName) || string.IsNullOrWhiteSpace(routingKey) ||
+            publishObject == null)
+            return;
+
+        using (_outMetricsFactory.CreateLoggingMetricsTimer(metricEntity, $"{exchangeName}:{routingKey}"))
+        {
+            var messageProperties = GetProperties(additionalHeaders, withAcceptLang);
+            var exchange = new Exchange(exchangeName);
+            var bodySerializer = serializer ?? _jsonSerializer;
+            var body = bodySerializer.ToJsonBytes(publishObject);
+
+            var sendingResult = await SetupPolicy(timeout).ExecuteAndCaptureAsync(async () =>
+                                    await _busClient.PublishAsync(
+                                        exchange,
+                                        routingKey,
+                                        mandatory,
+                                        messageProperties,
+                                        body));
+
+            if (sendingResult.FinalException != null)
+            {
+                _logger.ErrorWithObject(sendingResult.FinalException,
+                                        new { publishObject, exchangeName, routingKey, metricEntity, mandatory });
+            }
+        }
+    }
+
+    public Task SubscribeAsync(
+        string exchangeName,
+        string routingKey,
+        bool isExclusive,
+        bool isDurable,
+        bool isAutoDelete,
+        Func<byte[], MessageProperties, MessageReceivedInfo, Task> handler,
+        bool isExclusiveQueueName = false,
+        string customQueueName = null,
+        string metricEntity = null)
+    {
+        var binding = _rmqTopology.CreateBinding(exchangeName, routingKey, isExclusive, isDurable, isAutoDelete,
+                                                 isExclusiveQueueName, customQueueName);
+        return SubscribeAsync(binding, handler, metricEntity);
+    }
+
+    public async Task SubscribeAsync(
+        QueueExchangeBinding bindingInfo,
+        Func<byte[], MessageProperties, MessageReceivedInfo, Task> handler,
+        string metricEntity = null)
+    {
+        _subscriptions.Add(new SubscriptionInfo
+        {
+            Binding = bindingInfo,
+            EventbusSubscriptionHandler = handler,
+            MetricsEntity = metricEntity
+        });
+
+        RabbitMqDeclaredQueues.DeclaredQueues.Add(bindingInfo.Queue);
+
+        try
+        {
+            await SubscribePrivateAsync(bindingInfo, handler, metricEntity);
+        }
+        catch (Exception ex)
+        {
+            _logger.ErrorWithObject(ex,
+                                    "Initial subscription failed, trying to subscribe in background",
+                                    logObjects: bindingInfo.Queue.Name);
+            _subscribePolicy.ExecuteAsync(() => SubscribePrivateAsync(bindingInfo, handler, metricEntity)).Forget();
+        }
+    }
+
+    private AsyncPolicyWrap SetupPolicy(TimeSpan? timeout = null) =>
+        Policy.WrapAsync(Policy.TimeoutAsync(timeout ?? TimeSpan.FromSeconds(2)),
+                         Policy.Handle<Exception>()
+                               .WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(3)));
+
+    private async Task ExecuteWithPolicy(Func<Task> action)
+    {
+        var policy = Policy.Handle<TimeoutException>()
+                           .WaitAndRetryAsync(
+                               RetryAttemptMax,
+                               retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                               (exception, timeSpan, retryCount, _) =>
+                               {
+                                   _logger.ErrorWithObject(exception, new { TimeSpan = timeSpan, RetryCount = retryCount });
+                               });
+
+        var policyResult = await policy.ExecuteAndCaptureAsync(async () => await action.Invoke());
+
+        if (policyResult.FinalException != null)
+        {
+            _logger.ErrorWithObject(policyResult.FinalException, action);
+        }
+    }
+
+    private async Task ResubscribeOnReconnect()
+    {
+        _logger.Warn("Reconnect happened, start resubscribing");
+        foreach (var subscription in _subscriptions)
         {
             try
             {
-                _busClient = RabbitHutch.CreateBus(_connectionString,
-                    serviceRegister =>
-                    {
-                        serviceRegister.Register<IConventions>(c =>
-                            new RabbitMqConventions(c.Resolve<ITypeNameSerializer>(), _options));
-                    }).Advanced;
-
-                _busClient.Connected += async (_, _) => await ResubscribeOnReconnect();
-                _busClient.Disconnected += (_, _) => { _logger.Error("Disconnected from RMQ for some reason!"); };
-            }
-            catch (Exception exception)
-            {
-                _logger.Error(exception);
-            }
-
-            return Task.CompletedTask;
-        }
-
-        public Task<Exchange> DeclareExchangeTopicAsync(string exchangeName, bool durable, bool autoDelete) => 
-            _busClient.ExchangeDeclareAsync(exchangeName, ExchangeType.Topic, durable, autoDelete);
-
-        public async Task PublishRawAsync(
-            string publishBody,
-            string exchangeName,
-            string routingKey,
-            string metricEntity,
-            Dictionary<string, object> additionalHeaders = null,
-            bool mandatory = false,
-            TimeSpan? timeout = null,
-            bool withAcceptLang = true)
-        {
-            if (string.IsNullOrWhiteSpace(exchangeName) || string.IsNullOrWhiteSpace(routingKey) ||
-                string.IsNullOrWhiteSpace(publishBody))
-                return;
-
-            using (_metricsTracingFactory.CreateLoggingMetricsTimer(metricEntity))
-            {
-                var messageProperties = GetProperties(additionalHeaders, withAcceptLang);
-                var exchange = new Exchange(exchangeName);
-                var body = BodyEncoding.GetBytes(publishBody);
-
-                var sendingResult = await SetupPolicy(timeout).ExecuteAndCaptureAsync(async () =>
-                    await _busClient.PublishAsync(
-                        exchange,
-                        routingKey,
-                        mandatory,
-                        messageProperties,
-                        body));
-
-                if (sendingResult.FinalException != null)
-                {
-                    _logger.ErrorWithObject(sendingResult.FinalException,
-                        new { publishBody, exchangeName, routingKey, metricEntity, mandatory });
-                }
-            }
-        }
-
-        public async Task PublishAsync<T>(
-            T publishObject,
-            string exchangeName,
-            string routingKey,
-            string metricEntity,
-            Dictionary<string, object> additionalHeaders = null,
-            bool mandatory = false,
-            JsonSerializer serializer = null,
-            TimeSpan? timeout = null,
-            bool withAcceptLang = true)
-        {
-            if (string.IsNullOrWhiteSpace(exchangeName) || string.IsNullOrWhiteSpace(routingKey) ||
-                publishObject == null)
-                return;
-
-            using (_metricsTracingFactory.CreateLoggingMetricsTimer(metricEntity))
-            {
-                var messageProperties = GetProperties(additionalHeaders, withAcceptLang);
-                var exchange = new Exchange(exchangeName);
-                var bodySerializer = serializer ?? _jsonSerializer;
-                var body = bodySerializer.ToJsonBytes(publishObject);
-
-                var sendingResult = await SetupPolicy(timeout).ExecuteAndCaptureAsync(async () =>
-                    await _busClient.PublishAsync(
-                        exchange,
-                        routingKey,
-                        mandatory,
-                        messageProperties,
-                        body));
-
-                if (sendingResult.FinalException != null)
-                {
-                    _logger.ErrorWithObject(sendingResult.FinalException,
-                        new { publishObject, exchangeName, routingKey, metricEntity, mandatory });
-                }
-            }
-        }
-
-        public Task SubscribeAsync(
-            string exchangeName,
-            string routingKey,
-            bool isExclusive,
-            bool isDurable,
-            bool isAutoDelete,
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> handler,
-            bool isExclusiveQueueName = false,
-            string customQueueName = null,
-            string metricEntity = null)
-        {
-            var binding = _rmqTopology.CreateBinding(exchangeName, routingKey, isExclusive, isDurable, isAutoDelete,
-                isExclusiveQueueName, customQueueName);
-            return SubscribeAsync(binding, handler, metricEntity);
-        }
-
-        public async Task SubscribeAsync(
-            QueueExchangeBinding bindingInfo,
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> handler,
-            string metricEntity = null)
-        {
-            _subscriptions.Add(new SubscriptionInfo
-            {
-                Binding = bindingInfo,
-                EventbusSubscriptionHandler = handler,
-                MetricsEntity = metricEntity
-            });
-
-            RabbitMqDeclaredQueues.DeclaredQueues.Add(bindingInfo.Queue);
-
-            try
-            {
-                await SubscribePrivateAsync(bindingInfo, handler, metricEntity);
-            }
-            catch (Exception ex)
-            {
-                _logger.ErrorWithObject(ex,
-                                        "Initial subscription failed, trying to subscribe in background",
-                                        logObjects: bindingInfo.Queue.Name);
-                _subscribePolicy.ExecuteAsync(() => SubscribePrivateAsync(bindingInfo, handler, metricEntity)).Forget();
-            }
-        }
-
-        private AsyncPolicyWrap SetupPolicy(TimeSpan? timeout = null) =>
-            Policy.WrapAsync(Policy.TimeoutAsync(timeout ?? TimeSpan.FromSeconds(2)),
-                Policy.Handle<Exception>()
-                    .WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(3)));
-
-        private async Task ExecuteWithPolicy(Func<Task> action)
-        {
-            var policy = Policy.Handle<TimeoutException>()
-                .WaitAndRetryAsync(
-                    RetryAttemptMax,
-                    retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
-                    (exception, timeSpan, retryCount, _) =>
-                    {
-                        _logger.ErrorWithObject(exception, new { TimeSpan = timeSpan, RetryCount = retryCount });
-                    });
-
-            var policyResult = await policy.ExecuteAndCaptureAsync(async () => await action.Invoke());
-
-            if (policyResult.FinalException != null)
-            {
-                _logger.ErrorWithObject(policyResult.FinalException, action);
-            }
-        }
-
-        private async Task ResubscribeOnReconnect()
-        {
-            _logger.Warn("Reconnect happened, start resubscribing");
-            foreach (var subscription in _subscriptions)
-            {
-                try
-                {
-                    await ResubscribeInternalAsync(subscription);
-                }
-                catch (Exception e)
-                {
-                    _logger.ErrorWithObject(e, "Failed to resubscribe", logObjects: subscription.Binding.Queue.Name);
-                    _retryForeverPolicy.ExecuteAsync(() => ResubscribeInternalAsync(subscription)).Forget();
-                }
-            }
-
-            async Task ResubscribeInternalAsync(SubscriptionInfo sub)
-            {
-                if (sub.Binding.Queue.IsExclusive)
-                {
-                    await SubscribePrivateAsync(sub.Binding,
-                                                sub.EventbusSubscriptionHandler,
-                                                sub.MetricsEntity);
-                }
-                else
-                {
-                    // for non exclusive queues we reuse existing consumer
-                    // alternative is to dispose old consumer and create new consumer
-                    await DeclareBindQueue(sub.Binding);
-                }
-            }
-        }
-
-        private async Task SubscribePrivateAsync(
-            QueueExchangeBinding bindingInfo,
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> handler,
-            string metricEntity)
-        {
-            var queue = await DeclareBindQueue(bindingInfo);
-            _busClient.Consume(queue, HandleEventBusMessageWithPolicy);
-
-            async Task HandleEventBusMessageWithPolicy(ReadOnlyMemory<byte> body, MessageProperties props, MessageReceivedInfo info)
-            {
-                using (_metricsTracingFactory.CreateLoggingMetricsTimer(metricEntity ?? "Eventbus"))
-                {
-                    HandleMessageProps(props);
-                    await ExecuteWithPolicy(async () => await handler.Invoke(body.ToArray(), props, info));
-                }
-            }
-        }
-
-        private async Task<Queue> DeclareBindQueue(QueueExchangeBinding bindingInfo)
-        {
-            var queue = await _busClient.QueueDeclareAsync(
-                            name: bindingInfo.Queue.Name,
-                            autoDelete: bindingInfo.Queue.IsAutoDelete,
-                            durable: bindingInfo.Queue.IsDurable,
-                            exclusive: bindingInfo.Queue.IsExclusive);
-
-            var exchange = new Exchange(bindingInfo.Exchange.Name,
-                                        bindingInfo.Exchange.Type,
-                                        bindingInfo.Queue.IsDurable,
-                                        bindingInfo.Queue.IsAutoDelete);
-
-            await _busClient.BindAsync(exchange, bindingInfo.Queue, bindingInfo.RoutingKey);
-            return queue;
-        }
-
-        private void HandleMessageProps(MessageProperties props)
-        {
-            if (!props.HeadersPresent)
-                return;
-
-            GetAcceptLanguageFromProperties(props);
-        }
-
-        private void GetAcceptLanguageFromProperties(MessageProperties props)
-        {
-            try
-            {
-                if (!props.Headers.TryGetValue(MessagePropertiesNames.AcceptLang, out var acceptLanguage))
-                    return;
-
-                var acceptLanguageStr = BodyEncoding.GetString((byte[])acceptLanguage);
-                FlowContext<RequestMetaData>.Current =
-                    new RequestMetaData
-                    {
-                        RabbitAcceptLanguage = acceptLanguageStr
-                    };
-
-                if (LocaleHelper.TryGetFromString(acceptLanguageStr, out var cultureInfo))
-                    CultureInfo.CurrentUICulture = cultureInfo;
+                await ResubscribeInternalAsync(subscription);
             }
             catch (Exception e)
             {
-                _logger.ErrorWithObject(e, message: "Error while parsing accept_language from properties", props);
+                _logger.ErrorWithObject(e, "Failed to resubscribe", logObjects: subscription.Binding.Queue.Name);
+                _retryForeverPolicy.ExecuteAsync(() => ResubscribeInternalAsync(subscription)).Forget();
             }
         }
 
-        private MessageProperties GetProperties(Dictionary<string, object> additionalHeaders, bool withAcceptLang)
+        async Task ResubscribeInternalAsync(SubscriptionInfo sub)
         {
-            var messageProperties = new MessageProperties
+            if (sub.Binding.Queue.IsExclusive)
             {
-                AppId = ServiceVariables.ServiceAsClientName
-            };
-
-            SetTraceHeadersFromActivity(messageProperties);
-            if (withAcceptLang)
-                SetAcceptLanguageHeader(messageProperties);
-
-            if (additionalHeaders != null)
-            {
-                foreach (var additionalHeader in additionalHeaders)
-                {
-                    messageProperties.Headers.TryAdd(additionalHeader.Key, additionalHeader.Value);
-                }
+                await SubscribePrivateAsync(sub.Binding,
+                                            sub.EventbusSubscriptionHandler,
+                                            sub.MetricsEntity);
             }
-
-            return messageProperties;
+            else
+            {
+                // for non exclusive queues we reuse existing consumer
+                // alternative is to dispose old consumer and create new consumer
+                await DeclareBindQueue(sub.Binding);
+            }
         }
+    }
 
-        private void SetTraceHeadersFromActivity(MessageProperties properties)
+    private async Task SubscribePrivateAsync(
+        QueueExchangeBinding bindingInfo,
+        Func<byte[], MessageProperties, MessageReceivedInfo, Task> handler,
+        string metricEntity)
+    {
+        var queue = await DeclareBindQueue(bindingInfo);
+        _busClient.Consume(queue, HandleEventBusMessageWithPolicy);
+
+        async Task HandleEventBusMessageWithPolicy(ReadOnlyMemory<byte> body, MessageProperties props, MessageReceivedInfo info)
         {
-            if (Activity.Current is not { Baggage: { } bgg })
+            using (_inMetricsFactory.CreateLoggingMetricsTimer(metricEntity ?? "Eventbus",
+                                                               $"{info.Exchange}:{info.RoutingKey}",
+                                                               additionalLabels: props.AppId ?? "Unknown"))
+            {
+                HandleMessageProps(props);
+                await ExecuteWithPolicy(async () => await handler.Invoke(body.ToArray(), props, info));
+            }
+        }
+    }
+
+    private async Task<Queue> DeclareBindQueue(QueueExchangeBinding bindingInfo)
+    {
+        var queue = await _busClient.QueueDeclareAsync(
+                        name: bindingInfo.Queue.Name,
+                        autoDelete: bindingInfo.Queue.IsAutoDelete,
+                        durable: bindingInfo.Queue.IsDurable,
+                        exclusive: bindingInfo.Queue.IsExclusive);
+
+        var exchange = new Exchange(bindingInfo.Exchange.Name,
+                                    bindingInfo.Exchange.Type,
+                                    bindingInfo.Queue.IsDurable,
+                                    bindingInfo.Queue.IsAutoDelete);
+
+        await _busClient.BindAsync(exchange, bindingInfo.Queue, bindingInfo.RoutingKey);
+        return queue;
+    }
+
+    private void HandleMessageProps(MessageProperties props)
+    {
+        if (!props.HeadersPresent)
+            return;
+
+        GetAcceptLanguageFromProperties(props);
+    }
+
+    private void GetAcceptLanguageFromProperties(MessageProperties props)
+    {
+        try
+        {
+            if (!props.Headers.TryGetValue(MessagePropertiesNames.AcceptLang, out var acceptLanguage))
                 return;
 
-            var baggageArray = bgg.ToArray();
-            if (baggageArray.Length == 0)
-                return;
-
-            var baggageProperties = baggageArray
-                .Select(b => $"{WebUtility.UrlEncode(b.Key)}={WebUtility.UrlEncode(b.Value)}");
-
-            properties.Headers.Add(MessagePropertiesNames.Baggage, string.Join(", ", baggageProperties));
-        }
-
-        private void SetAcceptLanguageHeader(MessageProperties properties)
-        {
-            var flowAcceptLang = FlowContext<RequestMetaData>.Current.AcceptLanguage;
-            if (flowAcceptLang != null)
-                properties.Headers.Add(MessagePropertiesNames.AcceptLang, flowAcceptLang);
-        }
-
-        public void Dispose()
-        {
-            // Сделано для удобства локального тестирования, удаляем наши созданные очереди
-            if (_options.DeleteQueuesOnApplicationShutdown && _busClient != null)
-            {
-                foreach (var queue in RabbitMqDeclaredQueues.DeclaredQueues)
+            var acceptLanguageStr = BodyEncoding.GetString((byte[])acceptLanguage);
+            FlowContext<RequestMetaData>.Current =
+                new RequestMetaData
                 {
-                    _busClient.QueueDelete(queue.Name);
-                }
+                    RabbitAcceptLanguage = acceptLanguageStr
+                };
+
+            if (LocaleHelper.TryGetFromString(acceptLanguageStr, out var cultureInfo))
+                CultureInfo.CurrentUICulture = cultureInfo;
+        }
+        catch (Exception e)
+        {
+            _logger.ErrorWithObject(e, message: "Error while parsing accept_language from properties", props);
+        }
+    }
+
+    private MessageProperties GetProperties(Dictionary<string, object> additionalHeaders, bool withAcceptLang)
+    {
+        var messageProperties = new MessageProperties
+        {
+            AppId = ServiceVariables.ServiceAsClientName
+        };
+
+        SetTraceHeadersFromActivity(messageProperties);
+        if (withAcceptLang)
+            SetAcceptLanguageHeader(messageProperties);
+
+        if (additionalHeaders != null)
+        {
+            foreach (var additionalHeader in additionalHeaders)
+            {
+                messageProperties.Headers.TryAdd(additionalHeader.Key, additionalHeader.Value);
             }
-
-            _busClient?.Dispose();
         }
 
-        public string InitStartConsoleMessage()
+        return messageProperties;
+    }
+
+    private void SetTraceHeadersFromActivity(MessageProperties properties)
+    {
+        if (Activity.Current is not { Baggage: { } bgg })
+            return;
+
+        var baggageArray = bgg.ToArray();
+        if (baggageArray.Length == 0)
+            return;
+
+        var baggageProperties = baggageArray
+            .Select(b => $"{WebUtility.UrlEncode(b.Key)}={WebUtility.UrlEncode(b.Value)}");
+
+        properties.Headers.Add(MessagePropertiesNames.Baggage, string.Join(", ", baggageProperties));
+    }
+
+    private void SetAcceptLanguageHeader(MessageProperties properties)
+    {
+        var flowAcceptLang = FlowContext<RequestMetaData>.Current.AcceptLanguage;
+        if (flowAcceptLang != null)
+            properties.Headers.Add(MessagePropertiesNames.AcceptLang, flowAcceptLang);
+    }
+
+    public void Dispose()
+    {
+        // Сделано для удобства локального тестирования, удаляем наши созданные очереди
+        if (_options.DeleteQueuesOnApplicationShutdown && _busClient != null)
         {
-            return "Start Eventbus initializer";
+            foreach (var queue in RabbitMqDeclaredQueues.DeclaredQueues)
+            {
+                _busClient.QueueDelete(queue.Name);
+            }
         }
 
-        public string InitEndConsoleMessage()
-        {
-            return "End Eventbus initializer";
-        }
+        _busClient?.Dispose();
+    }
+
+    public string InitStartConsoleMessage()
+    {
+        return "Start Eventbus initializer";
+    }
+
+    public string InitEndConsoleMessage()
+    {
+        return "End Eventbus initializer";
     }
 }

--- a/ATI.Services.RabbitMQ/EventbusManager.cs
+++ b/ATI.Services.RabbitMQ/EventbusManager.cs
@@ -38,8 +38,8 @@ public class EventbusManager : IDisposable, IInitializer
     private readonly JsonSerializer _jsonSerializer;
     private readonly string _connectionString;
 
-    private readonly MetricsFactory _inMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsDirection.In, nameof(EventbusManager), additionalSummaryLabels: "rmq_app_id");
-    private readonly MetricsFactory _outMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsDirection.Out, nameof(EventbusManager));
+    private readonly MetricsFactory _inMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsType.Subscribe, nameof(EventbusManager), additionalSummaryLabels: "rmq_app_id");
+    private readonly MetricsFactory _outMetricsFactory = MetricsFactory.CreateRabbitMqMetricsFactory(RabbitMetricsType.Publish, nameof(EventbusManager));
 
     private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
     private ConcurrentBag<SubscriptionInfo> _subscriptions = new();

--- a/README.md
+++ b/README.md
@@ -47,13 +47,32 @@
  {
    public async Task InitializeAsync()
    {
+       var binding = _rmqTopology.CreateBinding(
+                "your_exchange_name",
+                "your_routing_key", isExclusive: false,
+                isDurable: true, isAutoDelete: false);
+
+       await _eventbusManager.SubscribeAsync(binding, Handler);
    }
+   
+   //this wrapped by metric collection
+   private async Task Handler(byte[] message, MessageProperties properties, MessageReceivedInfo info)
+   {
+       var someEntityEvent = _jsonSerializer.Deserialize<SomeEntity>(message);
+   }
+   
+    public async Task SendEmailAsync(...)
+    {
+        //this wrapped by metric collection
+        await _eventbusManager.PublishAsync(email, "your_exchange_name", "your_routing_key", MetricEntity.SomeEntity);
+    }
    
    public string InitStartConsoleMessage() => $"Start initialization for {nameof(EventbusInitializer)}";
    public string InitEndConsoleMessage() => $"End initialization for {nameof(EventbusInitializer)}";
  }
 ```
-Регистрируем в качестве Singlton `RMQTopology`, если необходимо. 
+Регистрируем в качестве Singleton `RMQTopology`, если необходимо. 
+Можно не собирать метрики при получении и отправке сообщений в вашем сервисе, т.к. это уже сделано в EventbusManager 
 Готово.
 
 


### PR DESCRIPTION
## Changes
**DotNet7** and new atisu.services.common version.
Changes in metrics collection for EventbusManager. Now it's easier to divide incoming and outgoing metrics, added info about exchange, routingKey, appId(only for incoming messages).
Previous: 
- `default_nameEventbusManager{method_name="PublishAsync", ...}`
- `default_nameEventbusManager{method_name="SubscribeAsync", ...}`

Changed:
- `common_metric_rabbitmq_in{exchange_routing_key_name= "exchange:routeKey", rmq_app_id="AppId from incoming messages or Unknown"}`
- `common_metric_rabbitmq_out{exchange_routing_key_name="exchange:routeKey"}`