### PR TITLE
Configurable queue/сonsumer + ack strategies for handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
+          dotnet-version: '8.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
       - name: Build
         run: dotnet build --configuration Release

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
+          dotnet-version: '8.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
       - name: Pack
         run: dotnet pack --configuration Release /p:Version=${VERSION} --output .
       - name: Push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with: 
-          dotnet-version: '7.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
+          dotnet-version: '8.0.x' # SDK Version to use; x will use the latest version of the 6.0 channel
       - name: Build
         run: dotnet build --configuration Release /p:Version=${VERSION}
       - name: Pack

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="16.4.0-init-timeout-error-log-v0.1" />
+    <PackageReference Include="atisu.services.common" Version="16.4.0-init-timeout-error-log-v0.2" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="16.4.0-init-timeout-error-log-v0.2" />
+    <PackageReference Include="atisu.services.common" Version="16.4.0" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
+++ b/ATI.Services.RabbitMQ/ATI.Services.RabbitMQ.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Main">
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
     <Authors>Team Services</Authors>
     <Company>ATI</Company>
@@ -16,7 +16,7 @@
     <NoWarn>1701;1702;CS1591;CS1571;CS1573;CS1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="atisu.services.common" Version="15.0.0" />
+    <PackageReference Include="atisu.services.common" Version="16.4.0-init-timeout-error-log-v0.1" />
     <PackageReference Include="EasyNetQ" Version="7.4.3" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
+++ b/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
@@ -1,19 +1,30 @@
-﻿using EasyNetQ.Topology;
+﻿using System;
+using EasyNetQ;
+using EasyNetQ.Topology;
 
 namespace ATI.Services.RabbitMQ;
 
-public class QueueExchangeBinding
+/// <param name="queueConfiguration">Configuration for queue declare. This configuration will be overriden by params in SubscribeAsync method</param>
+/// <param name="consumerConfiguration">Configuration for consumer</param>
+public class QueueExchangeBinding(
+    ExchangeInfo exchange,
+    Queue queue,
+    string routingKey,
+    string queueType = QueueType.Quorum,
+    Action<IQueueDeclareConfiguration> queueConfiguration = null,
+    Action<ISimpleConsumeConfiguration> consumerConfiguration = null)
 {
-    public QueueExchangeBinding(ExchangeInfo exchange, Queue queue, string routingKey, string queueType = EasyNetQ.QueueType.Quorum)
-    {
-        Queue = queue;
-        RoutingKey = routingKey;
-        Exchange = exchange;
-        QueueType = queueType;
-    }
-
-    public Queue Queue { get; }
-    public string RoutingKey { get; }
-    public ExchangeInfo Exchange { get; }
-    public string QueueType { get; set; }
+    public Queue Queue { get; } = queue;
+    public string RoutingKey { get; } = routingKey;
+    public ExchangeInfo Exchange { get; } = exchange;
+    public string QueueType { get; } = queueType;
+    /// <summary>
+    /// Configuration for queue declare
+    /// This configuration will be overriden by params in SubscribeAsync method
+    /// </summary>
+    public Action<IQueueDeclareConfiguration> QueueConfiguration { get; } = queueConfiguration;
+    /// <summary>
+    /// Configuration for consumer
+    /// </summary>
+    public Action<ISimpleConsumeConfiguration> ConsumerConfiguration { get; } = consumerConfiguration;
 }

--- a/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
+++ b/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
@@ -14,6 +14,7 @@ public class QueueExchangeBinding(
     Action<IQueueDeclareConfiguration> queueConfiguration = null,
     Action<ISimpleConsumeConfiguration> consumerConfiguration = null)
 {
+    //for back compatibility release 
     [Obsolete("Use constructor with queueConfiguration and consumerConfiguration")]
     public QueueExchangeBinding(ExchangeInfo exchange,
                                 Queue queue,

--- a/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
+++ b/ATI.Services.RabbitMQ/QueueExchangeBinding.cs
@@ -14,6 +14,15 @@ public class QueueExchangeBinding(
     Action<IQueueDeclareConfiguration> queueConfiguration = null,
     Action<ISimpleConsumeConfiguration> consumerConfiguration = null)
 {
+    [Obsolete("Use constructor with queueConfiguration and consumerConfiguration")]
+    public QueueExchangeBinding(ExchangeInfo exchange,
+                                Queue queue,
+                                string routingKey,
+                                string queueType = EasyNetQ.QueueType.Quorum)
+        :this(exchange, queue, routingKey, queueType, null, null)
+    {
+    }
+    
     public Queue Queue { get; } = queue;
     public string RoutingKey { get; } = routingKey;
     public ExchangeInfo Exchange { get; } = exchange;

--- a/ATI.Services.RabbitMQ/SubscriptionInfo.cs
+++ b/ATI.Services.RabbitMQ/SubscriptionInfo.cs
@@ -16,6 +16,4 @@ public class SubscriptionInfo
 
     public Task ResubscribeTask { get; set; }
     public object ResubscribeLock { get; } = new();
-    
-    public Action<ISimpleConsumeConfiguration> ConsumerConfiguration { get; set; }
 }

--- a/ATI.Services.RabbitMQ/SubscriptionInfo.cs
+++ b/ATI.Services.RabbitMQ/SubscriptionInfo.cs
@@ -1,16 +1,21 @@
 ﻿using System;
 using System.Threading.Tasks;
 using EasyNetQ;
+using EasyNetQ.Consumer;
 
 namespace ATI.Services.RabbitMQ;
 
 public class SubscriptionInfo
 {
     public QueueExchangeBinding Binding { get; set; }
-    public Func<byte[], MessageProperties, MessageReceivedInfo, Task> EventbusSubscriptionHandler { get; set; }
+
+    public Func<byte[], MessageProperties, MessageReceivedInfo, Task<AckStrategy>> EventbusSubscriptionHandler { get; set; }
+
     public string MetricsEntity { get; set; }
     public IDisposable Consumer { get; set; }
 
     public Task ResubscribeTask { get; set; }
     public object ResubscribeLock { get; } = new();
+    
+    public Action<ISimpleConsumeConfiguration> ConsumerConfiguration { get; set; }
 }


### PR DESCRIPTION
DotNet8

#### Configurable queue and consumer.
Create subscription with queueConfiguration and consumerConfiguration.
<details><summary>Example</summary>
<p>

```c#

var binding = rmqTopology.CreateBinding(
    "exchange_name",
    "routing_key", isExclusive: false, isDurable: true, isAutoDelete: false,
    queueConfiguration: c =>
    {
        c.AsExclusive(false); // will be overriden by param isExclusive
        c.AsDurable(false); // will be overriden by param isDurable
        c.AsAutoDelete(false); // will be overriden by param isAutoDelete
        
        c.WithArgument("x-normal-size", 1000);
        c.WithArgument("message-ttl", 60000);   //sets message-ttl for this queue
    },
    consumerConfiguration: c => c.WithPrefetchCount(1)); // sets prefetch=1 for this consumer
await eventbusManager.SubscribeAsync(contactOverLimitBinding, Handler);

``` 

</p>
</details> 

#### Handler with Ack strategies
Added message handler overload that allows to use different Ack strategies.
<details><summary>Example</summary>
<p>

```c#

private async Task<AckStrategy> Handler(byte[] body, MessageProperties prop, MessageReceivedInfo info)
{
    if (body == ...)
    {
        //some work
        return AckStrategies.Ack;
    }

    return AckStrategies.NackWithRequeue;
}
``` 

</p>
</details> 






